### PR TITLE
Removes unnecessary status content_types.

### DIFF
--- a/nautobot_firewall_models/migrations/0002_custom_status.py
+++ b/nautobot_firewall_models/migrations/0002_custom_status.py
@@ -18,6 +18,7 @@ def create_status(apps, schema_editor):
                 ct = ContentType.objects.get_for_model(model)
                 status.content_types.add(ct)
 
+
 def reverse_create_status(apps, schema_editor):
     """Reverse adding firewall models to status content_types."""
 
@@ -41,6 +42,7 @@ def create_default_objects(apps, schema_editor):
     for i in services:
         apps.get_model("nautobot_firewall_models.ServiceObject").objects.create(status=status, **i)
 
+
 def reverse_create_default_objects(apps, schema_editor):
     """Removes commonly used objects."""
     defaults = os.path.join(os.path.dirname(__file__), "services.yml")
@@ -54,6 +56,7 @@ def reverse_create_default_objects(apps, schema_editor):
             service.delete()
         except ObjectDoesNotExist:
             continue
+
 
 class Migration(migrations.Migration):
 

--- a/nautobot_firewall_models/migrations/0002_custom_status.py
+++ b/nautobot_firewall_models/migrations/0002_custom_status.py
@@ -2,10 +2,11 @@
 import os
 
 from django.db import migrations
+from django.core.exceptions import ObjectDoesNotExist
 import yaml
 
 
-def create_status(apps, schedma_editor):
+def create_status(apps, schema_editor):
     """Initial subset of statuses."""
 
     statuses = ["active", "staged", "decommissioned"]
@@ -13,8 +14,21 @@ def create_status(apps, schedma_editor):
     for i in statuses:
         status = apps.get_model("extras.Status").objects.get(slug=i)
         for model in apps.app_configs["nautobot_firewall_models"].get_models():
-            ct = ContentType.objects.get_for_model(model)
-            status.content_types.add(ct)
+            if hasattr(model, "status"):
+                ct = ContentType.objects.get_for_model(model)
+                status.content_types.add(ct)
+
+def reverse_create_status(apps, schema_editor):
+    """Reverse adding firewall models to status content_types."""
+
+    statuses = ["active", "staged", "decommissioned"]
+    ContentType = apps.get_model("contenttypes.ContentType")
+    for i in statuses:
+        status = apps.get_model("extras.Status").objects.get(slug=i)
+        for model in apps.app_configs["nautobot_firewall_models"].get_models():
+            if hasattr(model, "status"):
+                ct = ContentType.objects.get_for_model(model)
+                status.content_types.remove(ct)
 
 
 def create_default_objects(apps, schema_editor):
@@ -27,6 +41,19 @@ def create_default_objects(apps, schema_editor):
     for i in services:
         apps.get_model("nautobot_firewall_models.ServiceObject").objects.create(status=status, **i)
 
+def reverse_create_default_objects(apps, schema_editor):
+    """Removes commonly used objects."""
+    defaults = os.path.join(os.path.dirname(__file__), "services.yml")
+    with open(defaults, "r") as f:
+        services = yaml.safe_load(f)
+    status = apps.get_model("extras.Status").objects.get(slug="active")
+
+    for i in services:
+        try:
+            service = apps.get_model("nautobot_firewall_models.ServiceObject").objects.get(status=status, **i)
+            service.delete()
+        except ObjectDoesNotExist:
+            continue
 
 class Migration(migrations.Migration):
 
@@ -36,6 +63,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(code=create_status),
-        migrations.RunPython(code=create_default_objects),
+        migrations.RunPython(code=create_status, reverse_code=reverse_create_status),
+        migrations.RunPython(code=create_default_objects, reverse_code=reverse_create_default_objects),
     ]

--- a/nautobot_firewall_models/migrations/0007_renaming_part2.py
+++ b/nautobot_firewall_models/migrations/0007_renaming_part2.py
@@ -3,7 +3,7 @@ from django.db import migrations
 from django.db.models import Count
 
 
-def move_index(apps, schedma_editor):
+def move_index(apps, schema_editor):
     """Custom migration for moving index to the PolicyRule."""
     # Get models to work with
     PolicyRuleM2M = apps.get_model("nautobot_firewall_models.PolicyRuleM2M")
@@ -51,5 +51,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(code=move_index),
+        # TODO Provide Code to Reverse the move_index function
+        migrations.RunPython(code=move_index, reverse_code=migrations.RunPython.noop),
     ]

--- a/nautobot_firewall_models/migrations/0011_custom_status_nat.py
+++ b/nautobot_firewall_models/migrations/0011_custom_status_nat.py
@@ -3,7 +3,7 @@
 from django.db import migrations
 
 
-def create_nat_status(apps, schedma_editor):
+def create_nat_status(apps, schema_editor):
     """Initial subset of statuses for the NAT models.
 
     This was added along with 0009_nat_policy in order to associate the same set of statuses with the new NAT models
@@ -22,6 +22,24 @@ def create_nat_status(apps, schedma_editor):
             ct = ContentType.objects.get_for_model(model)
             status.content_types.add(ct)
 
+def remove_nat_status(apps, schema_editor):
+    """Remove status content_type for NAT models.
+
+    This was added along with 0009_nat_policy in order to associate the same set of statuses with the new NAT models
+    that are associated with the original set of security models.
+    """
+
+    statuses = ["active", "staged", "decommissioned"]
+    ContentType = apps.get_model("contenttypes.ContentType")
+    relevant_models = [
+        apps.get_model(model)
+        for model in ["nautobot_firewall_models.NATPolicy", "nautobot_firewall_models.NATPolicyRule"]
+    ]
+    for i in statuses:
+        status = apps.get_model("extras.Status").objects.get(slug=i)
+        for model in relevant_models:
+            ct = ContentType.objects.get_for_model(model)
+            status.content_types.remove(ct)
 
 class Migration(migrations.Migration):
 
@@ -31,5 +49,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(code=create_nat_status),
+        migrations.RunPython(code=create_nat_status, reverse_code=remove_nat_status),
     ]

--- a/nautobot_firewall_models/migrations/0011_custom_status_nat.py
+++ b/nautobot_firewall_models/migrations/0011_custom_status_nat.py
@@ -22,6 +22,7 @@ def create_nat_status(apps, schema_editor):
             ct = ContentType.objects.get_for_model(model)
             status.content_types.add(ct)
 
+
 def remove_nat_status(apps, schema_editor):
     """Remove status content_type for NAT models.
 
@@ -40,6 +41,7 @@ def remove_nat_status(apps, schema_editor):
         for model in relevant_models:
             ct = ContentType.objects.get_for_model(model)
             status.content_types.remove(ct)
+
 
 class Migration(migrations.Migration):
 

--- a/nautobot_firewall_models/migrations/0012_remove_status_m2m_through_models.py
+++ b/nautobot_firewall_models/migrations/0012_remove_status_m2m_through_models.py
@@ -1,0 +1,27 @@
+
+from django.db import migrations
+
+
+def remove_m2m_through_status_content_types(apps, schema_editor):
+    """Remove the through model content types from the Status objects."""
+
+    statuses = ["active", "staged", "decommissioned"]
+    ContentType = apps.get_model("contenttypes.ContentType")
+    for i in statuses:
+        status = apps.get_model("extras.Status").objects.get(slug=i)
+        for model in apps.app_configs["nautobot_firewall_models"].get_models():
+            if not hasattr(model, "status"):
+                ct = ContentType.objects.get_for_model(model)
+                status.content_types.remove(ct)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("extras", "0033_add__optimized_indexing"),
+        ("nautobot_firewall_models", "0011_custom_status_nat"),
+    ]
+
+    operations = [
+        migrations.RunPython(code=remove_m2m_through_status_content_types, reverse_code=migrations.RunPython.noop),
+    ]

--- a/nautobot_firewall_models/migrations/0012_remove_status_m2m_through_models.py
+++ b/nautobot_firewall_models/migrations/0012_remove_status_m2m_through_models.py
@@ -1,4 +1,3 @@
-
 from django.db import migrations
 
 


### PR DESCRIPTION
FIXES: #86 

This PR fixes a bug that migration 0002 create_status would add all models instead of only the models that support statuses.  A fix of this migration has been provided in addition to a new migration 0012 to cleanup these statuses for anyone already running the plugin.

In addition to these fixes, I am adding reverse_code for all of the RunPython migrations so that when removing this app, you can do `migrate nautobot_firewall_models zero`.