### PR TITLE
Remove redundant get_queryset in NATPolicyUIViewSet

### DIFF
--- a/nautobot_firewall_models/views/nat_policy.py
+++ b/nautobot_firewall_models/views/nat_policy.py
@@ -3,7 +3,6 @@
 from django.shortcuts import redirect
 from django.urls import reverse
 from nautobot.apps.views import NautobotUIViewSet
-from nautobot.core.views.mixins import PERMISSIONS_ACTION_MAP
 from rest_framework.decorators import action
 
 from nautobot_firewall_models import details, filters, forms, models, tables


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Firewall Models! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>

## What's Changed

This should have been done in the original permissions fix PR. I made this change to the PolicyUIViewSet but I missed it on NATPolicy.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
