### PR TITLE
Backport: Prefix names starting with numbers with an underscore in slugify()

### DIFF
--- a/changes/360.fixed
+++ b/changes/360.fixed
@@ -1,0 +1,1 @@
+Fixed an incompatibility when slugifying capirca names that start with a number by prefixing the name with an underscore.

--- a/nautobot_firewall_models/utils/capirca.py
+++ b/nautobot_firewall_models/utils/capirca.py
@@ -33,11 +33,17 @@ def _slugify(value):
     dashes to single dashes. Remove characters that aren't alphanumerics,
     underscores, or hyphens. Convert to lowercase. Also strip leading and
     trailing whitespace, dashes, and underscores.
+    Also adds a leading underscore to names starting with an number to circumvent a bug in the Capirca/Aerleon parser.
     """
     value = str(value)
     value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
     value = re.sub(r"[^\w\s-]", "", value)
-    return re.sub(r"[-\s]+", "-", value).strip("-_")
+    value = re.sub(r"[-\s]+", "-", value).strip("-_")
+
+    if value[:1].isnumeric():
+        value = "_" + value
+
+    return value
 
 
 def _list_slugify(values):


### PR DESCRIPTION
## What's Changed
Backports a fix to ensure Capirca names starting with a number are slugified with a leading underscore.


## To Do
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
